### PR TITLE
Issue#12

### DIFF
--- a/integration_test/debezium/setup.sql
+++ b/integration_test/debezium/setup.sql
@@ -16,8 +16,8 @@ CREATE TABLE timesource (
     id INTEGER NOT NULL PRIMARY KEY,
     "alphA" DATE,
     beta TIME(3),
-    gamma TIMESTAMP(6),
-    delta TIMESTAMPTZ(6)
+    gamma TIMESTAMP(3),
+    delta TIMESTAMPTZ(3)
 );
 
 CREATE TABLE binarysource (
@@ -42,7 +42,7 @@ new line'),
 
 INSERT INTO timesource
 VALUES (1, '2017-09-18', '10:29:00', '2017-09-29 15:00:00.0', '2017-09-29 15:00:00.0'),
-       (2, '2017-09-18', '10:29:00.123', '2017-09-29 15:00:00.0123', '2017-09-29 15:00:00.0123');
+       (2, '2017-09-18', '10:29:00.123', '2017-09-29 15:00:00.012', '2017-09-29 15:00:00.012');
 
 INSERT INTO binarysource
 VALUES (1, decode('1A1B1C3D1F', 'hex'), true, B'110000011101100'),
@@ -78,8 +78,8 @@ CREATE TABLE timetarget (
     id INTEGER NOT NULL PRIMARY KEY,
     alpha DATE,
     beta TIME(5),
-    gamma TIMESTAMP(6),
-    delta TIMESTAMPTZ(6)
+    gamma TIMESTAMP(3),
+    delta TIMESTAMPTZ(3)
 );
 
 CREATE TABLE binarytarget (

--- a/integration_test/debezium/setup.sql
+++ b/integration_test/debezium/setup.sql
@@ -15,7 +15,9 @@ CREATE TABLE charsource (
 CREATE TABLE timesource (
     id INTEGER NOT NULL PRIMARY KEY,
     "alphA" DATE,
-    beta TIME(3)
+    beta TIME(3),
+    gamma TIMESTAMP(6),
+    delta TIMESTAMPTZ(6)
 );
 
 CREATE TABLE binarysource (
@@ -39,8 +41,8 @@ new line'),
        (3, 'abcde', '', '');
 
 INSERT INTO timesource
-VALUES (1, '2017-09-18', '10:29:00'),
-       (2, '2017-09-18', '10:29:00.123');
+VALUES (1, '2017-09-18', '10:29:00', '2017-09-29 15:00:00.0', '2017-09-29 15:00:00.0'),
+       (2, '2017-09-18', '10:29:00.123', '2017-09-29 15:00:00.0123', '2017-09-29 15:00:00.0123');
 
 INSERT INTO binarysource
 VALUES (1, decode('1A1B1C3D1F', 'hex'), true, B'110000011101100'),
@@ -75,7 +77,9 @@ CREATE TABLE chartarget (
 CREATE TABLE timetarget (
     id INTEGER NOT NULL PRIMARY KEY,
     alpha DATE,
-    beta TIME(5)
+    beta TIME(5),
+    gamma TIMESTAMP(6),
+    delta TIMESTAMPTZ(6)
 );
 
 CREATE TABLE binarytarget (

--- a/integration_test/maxwell/mysql_setup.sql
+++ b/integration_test/maxwell/mysql_setup.sql
@@ -15,7 +15,8 @@ CREATE TABLE charsource (
 CREATE TABLE timesource (
     id INTEGER NOT NULL PRIMARY KEY,
     alpha DATE,
-    beta TIME(3)
+    beta TIME(3),
+    gamma TIMESTAMP(6)
 );
 
 CREATE TABLE binarysource (
@@ -39,8 +40,8 @@ new line'),
        (3, 'abcde', '', '');
 
 INSERT INTO timesource
-VALUES (1, '2017-09-18', '10:29:00'),
-       (2, '2017-09-18', '10:29:00.123');
+VALUES (1, '2017-09-18', '10:29:00', '2017-09-29 15:00:00.0'),
+       (2, '2017-09-18', '10:29:00.123', '2017-09-29 15:00:00.0123');
 
 INSERT INTO binarysource
 VALUES (1, X'1A1B1C3D1F', false, B'110000011101100'),

--- a/integration_test/maxwell/pg_setup.sql
+++ b/integration_test/maxwell/pg_setup.sql
@@ -15,7 +15,8 @@ CREATE TABLE chartarget (
 CREATE TABLE timetarget (
     id INTEGER NOT NULL PRIMARY KEY,
     alpha DATE,
-    beta TIME(5)
+    beta TIME(5),
+    gamma TIMESTAMP(6)
 );
 
 CREATE TABLE binarytarget (

--- a/pom.xml
+++ b/pom.xml
@@ -31,11 +31,6 @@
 			<version>2.8.2</version>
 		</dependency>
 		<dependency>
-			<groupId>mysql</groupId>
-			<artifactId>mysql-connector-java</artifactId>
-			<version>5.1.39</version>
-		</dependency>
-		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.12</version>

--- a/src/main/java/cn/hashdata/bireme/provider/DebeziumProvider.java
+++ b/src/main/java/cn/hashdata/bireme/provider/DebeziumProvider.java
@@ -196,11 +196,18 @@ public class DebeziumProvider extends KafkaProvider {
       StringBuilder sb = new StringBuilder();
 
       switch (fieldType) {
-        case Types.TIME: {
+        case Types.TIME:
+        case Types.TIMESTAMP: {
           int sec = Integer.parseInt(data.substring(0, data.length() - 9));
           String fraction = data.substring(data.length() - 9, data.length() - 9 + precision);
           Date d = new Date(sec * 1000L);
-          SimpleDateFormat df = new SimpleDateFormat("HH:mm:ss");
+
+          SimpleDateFormat df;
+          if (fieldType == Types.TIME) {
+            df = new SimpleDateFormat("HH:mm:ss");
+          } else {
+            df = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+          }
           df.setTimeZone(TimeZone.getTimeZone("GMT"));
 
           sb.append(df.format(d));
@@ -236,7 +243,7 @@ public class DebeziumProvider extends KafkaProvider {
     protected String decodeToNumeric(String data, int fieldType, int precision) {
       byte[] value = Base64.decodeBase64(data);
       BigDecimal bigDecimal = new BigDecimal(new BigInteger(value), precision);
-      
+
       return bigDecimal.toString();
     }
   }

--- a/src/main/java/cn/hashdata/bireme/provider/DebeziumProvider.java
+++ b/src/main/java/cn/hashdata/bireme/provider/DebeziumProvider.java
@@ -198,6 +198,12 @@ public class DebeziumProvider extends KafkaProvider {
       switch (fieldType) {
         case Types.TIME:
         case Types.TIMESTAMP: {
+          // For TIMETZ and TIMESTAMPTZ, debezium will send the right format which can be load
+          // directly.
+          if (data.contains(String.valueOf('Z'))) {
+            return data;
+          }
+
           int sec = Integer.parseInt(data.substring(0, data.length() - 9));
           String fraction = data.substring(data.length() - 9, data.length() - 9 + precision);
           Date d = new Date(sec * 1000L);


### PR DESCRIPTION
Support timestamp and timestamptz for debezium. But debezium represents the number of milliseconds past epoch, resulting in a loss of precision if the source type has a scale more than 3.